### PR TITLE
:bug: [open-formulieren/open-forms#5435] skip validation for hidden selectboxes

### DIFF
--- a/src/components/selectboxes/SelectBoxes.js
+++ b/src/components/selectboxes/SelectBoxes.js
@@ -192,6 +192,12 @@ export default class SelectBoxesComponent extends RadioComponent {
   }
 
   checkComponentValidity(data, dirty, rowData, options) {
+    // check if we need to skip validation before calling isValid
+    if (this.shouldSkipValidation(data, dirty, rowData)) {
+      this.setCustomValidity('');
+      return true;
+    }
+
     const minCount = this.component.validate.minSelectedCount;
     const maxCount = this.component.validate.maxSelectedCount;
     const isValid = this.isValid(data, dirty);


### PR DESCRIPTION
fixes https://github.com/open-formulieren/open-forms/issues/5435

Explanation:

When `selectboxes` components is placed inside a hidden fieldset then it has properties `conditionallyVisible` = true but 
`visible` = false. 
In the `SelectBoxes.checkComponentValidity` method `isValid` method is called, which calls `Validator.validate`, which  uses `conditionallyVisible` property. Therefore we have invisible but invalid component. 
The validation should be skipped in this case, so `shouldSkipValidation` is added before `isValid`
